### PR TITLE
Add eye extraction features

### DIFF
--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -206,10 +206,12 @@ def generate_images(
         img.save(f'{outdir}/seed{seed:04d}.png')
 
         if eyes:
-            depths = np.array([depth_img.cpu() for depth_img in depths]).squeeze()
-            for i in range(np.shape(depths)[0]):
-                d_img = depths[i][30:70, 20:-20]
-                d_img = np.clip(img, np.min(img), np.max(img) * 0.95)
+            d_imgs = np.array([depth_img.cpu() for depth_img in depths]).squeeze()
+            d_imgs = d_imgs.squeeze()
+            print(np.shape(d_imgs))
+            for i in range(np.shape(d_imgs)[0]):
+                d_img = d_imgs[i][30:70, 20:-20]
+                d_img = np.clip(d_img, np.min(img), np.max(img) * 0.95)
                 plt.imshow(d_img, interpolation='none')
 
                 plt.savefig(f'{outdir}/seed{seed:04d}-depth{i}.png')

--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -163,7 +163,7 @@ def generate_images(
     cam2world_pose = LookAtPoseSampler.sample(3.14/2, 3.14/2, torch.tensor([0, 0, 0.2], device=device), radius=2.7, device=device)
     intrinsics = FOV_to_intrinsics(fov_deg, device=device)
 
-    svm_coef_dir = './style_editing/svm_coefs'
+    svm_coef_dir = './kaggle/working/style_editing/svm_coefs'
     coef = np.load(os.path.join(svm_coef_dir, 'coef.npy'))
     coef = torch.tensor(coef, device=device)
 

--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -163,7 +163,7 @@ def generate_images(
     cam2world_pose = LookAtPoseSampler.sample(3.14/2, 3.14/2, torch.tensor([0, 0, 0.2], device=device), radius=2.7, device=device)
     intrinsics = FOV_to_intrinsics(fov_deg, device=device)
 
-    svm_coef_dir = './kaggle/working/style_editing/svm_coefs'
+    svm_coef_dir = '/kaggle/working/dl-project/style_editing/svm_coefs'
     coef = np.load(os.path.join(svm_coef_dir, 'coef.npy'))
     coef = torch.tensor(coef, device=device)
 

--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -163,7 +163,7 @@ def generate_images(
     cam2world_pose = LookAtPoseSampler.sample(3.14/2, 3.14/2, torch.tensor([0, 0, 0.2], device=device), radius=2.7, device=device)
     intrinsics = FOV_to_intrinsics(fov_deg, device=device)
 
-    svm_coef_dir = '../style_editing/svm_coefs'
+    svm_coef_dir = './style_editing/svm_coefs'
     coef = np.load(os.path.join(svm_coef_dir, 'coef.npy'))
     coef = torch.tensor(coef, device=device)
 

--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -163,7 +163,7 @@ def generate_images(
     cam2world_pose = LookAtPoseSampler.sample(3.14/2, 3.14/2, torch.tensor([0, 0, 0.2], device=device), radius=2.7, device=device)
     intrinsics = FOV_to_intrinsics(fov_deg, device=device)
 
-    svm_coef_dir = '/kaggle/working/dl-project/style_editing/svm_coefs'
+    svm_coef_dir = '../style_editing/svm_coefs'
     coef = np.load(os.path.join(svm_coef_dir, 'coef.npy'))
     coef = torch.tensor(coef, device=device)
 

--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -208,16 +208,21 @@ def generate_images(
         if eyes:
             d_imgs = np.array([depth_img.cpu() for depth_img in depths]).squeeze()
             d_imgs = d_imgs.squeeze()
-            print(np.shape(d_imgs))
+            one_image = False
+            if d_imgs.shape <= 2:
+                one_image = True
+                d_img = d_imgs
             for i in range(np.shape(d_imgs)[0]):
-                d_img = d_imgs[i][30:70, 20:-20]
+                if not one_image:
+                    d_img = d_imgs[i]
+                d_img = d_img[30:70, 20:-20]
                 d_img = np.clip(d_img, np.min(img), np.max(img) * 0.95)
                 plt.imshow(d_img, interpolation='none')
 
                 plt.savefig(f'{outdir}/seed{seed:04d}-depth{i}.png')
                 plt.close()
-
-
+                if one_image:
+                    break
 
         if shapes:
             # extract a shape.mrc with marching cubes. You can view the .mrc file using ChimeraX from UCSF.

--- a/eg3d/gen_samples.py
+++ b/eg3d/gen_samples.py
@@ -209,7 +209,7 @@ def generate_images(
             d_imgs = np.array([depth_img.cpu() for depth_img in depths]).squeeze()
             d_imgs = d_imgs.squeeze()
             one_image = False
-            if d_imgs.shape <= 2:
+            if len(d_imgs.shape) <= 2:
                 one_image = True
                 d_img = d_imgs
             for i in range(np.shape(d_imgs)[0]):


### PR DESCRIPTION
Won't work on my kaggle because it is missing a file that is clearly there so see if this works for you locally before merging. If --eyes is set to true the model should output a mrc file only encompassing the eye section and a depth image of the actual image again centered around the eyes